### PR TITLE
[#23] Expose internal errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/Yelp/detect-secrets
-  rev: v1.0.3
+  rev: v1.4.0
   hooks:
   - id: detect-secrets
     args: ['--baseline', '.secrets.baseline'] 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Expose internal errors [#23](https://github.com/rokwire/logging-library-go/issues/23)
+
 ## [2.1.0] - 2022-12-01
 ### Added
 - Regex in HTTPRequestProperties [#20](https://github.com/rokwire/logging-library-go/issues/20)

--- a/errors/error.go
+++ b/errors/error.go
@@ -154,6 +154,16 @@ func (e *Error) HasTag(tag string) bool {
 	return logutils.ContainsString(e.tags, tag)
 }
 
+// HasErrorLabel returns true if label is a substring of the trace
+func (e Error) HasErrorLabel(label string) bool {
+	if i, ok := e.internal.(interface {
+		HasErrorLabel(label string) bool
+	}); ok {
+		return i.HasErrorLabel(label)
+	}
+	return false
+}
+
 func (e Error) wrap(context *ErrorContext) *Error {
 	if context == nil {
 		return &e

--- a/errors/error.go
+++ b/errors/error.go
@@ -74,6 +74,14 @@ func (e *Error) RootContext() string {
 	return root
 }
 
+// Internal returns the internal error
+func (e *Error) Internal() error {
+	if e == nil {
+		return nil
+	}
+	return e.internal
+}
+
 // Trace returns the trace messages
 func (e *Error) Trace() string {
 	if e == nil {
@@ -152,16 +160,6 @@ func (e *Error) HasTag(tag string) bool {
 		return false
 	}
 	return logutils.ContainsString(e.tags, tag)
-}
-
-// HasErrorLabel returns true if the internal error has label
-func (e Error) HasErrorLabel(label string) bool {
-	if i, ok := e.internal.(interface {
-		HasErrorLabel(label string) bool
-	}); ok {
-		return i.HasErrorLabel(label)
-	}
-	return false
 }
 
 func (e Error) wrap(context *ErrorContext) *Error {

--- a/errors/error.go
+++ b/errors/error.go
@@ -154,7 +154,7 @@ func (e *Error) HasTag(tag string) bool {
 	return logutils.ContainsString(e.tags, tag)
 }
 
-// HasErrorLabel returns true if label is a substring of the trace
+// HasErrorLabel returns true if the internal error has label
 func (e Error) HasErrorLabel(label string) bool {
 	if i, ok := e.internal.(interface {
 		HasErrorLabel(label string) bool


### PR DESCRIPTION
## Description
This PR adds a getter function called `errors.Error.Internal()`, which returns `Error.internal`.

**Resolves #23**

[comment]: # (This project only accepts pull requests related to open issues.)
[comment]: # (If suggesting a new feature or change, please discuss it in an issue first.)
[comment]: # (If fixing a bug, there should be an issue describing it with steps to reproduce.)

## Review Time Estimate
_Please give your idea of how soon this pull request needs to be reviewed by selecting one of the options below. This can be based on the criticality of the issue at hand and/or other relevant factors._

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] Immediately
- [ ] Within a week
- [ ] When possible

## Type of changes
_Please select a relevant option:_

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
_Please select all applicable options:_

[comment]: # (To select your options, please put an 'x' in the all boxes that apply.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [x] I have updated the [CHANGELOG](../CHANGELOG.md).
- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

---

[comment]: # (Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates.)
